### PR TITLE
Fix of excl_bands and Instrument class/subclasses

### DIFF
--- a/NIRCam_pipeline/pipeline.py
+++ b/NIRCam_pipeline/pipeline.py
@@ -30,7 +30,7 @@ def pipeline(surveys, version, instruments, aper_diams, min_flux_pc_errs, forced
             print(str(cat))
             #print(str(cat[0]))
 
-            cat_copy = cat.select_EPOCHS(allow_lowz = False)
+            #cat_copy = cat.select_EPOCHS(allow_lowz = False)
             #cat_copy.plot_phot_diagnostics()
 
 
@@ -59,9 +59,9 @@ def make_EAZY_SED_fit_params_arr(SED_code_arr, templates_arr, lowz_zmax_arr):
 
 if __name__ == "__main__":
     version = "v9" #config["DEFAULT"]["VERSION"]
-    instruments = ["NIRCam"] #, 'ACS_WFC'] #, 'WFC3_IR']
+    instruments = ["ACS_WFC", "NIRCam"] #, 'WFC3_IR'] # "ACS_WFC"
     cat_type = "loc_depth"
-    surveys = ["JADES-Deep-GS+JEMS"] #[config["DEFAULT"]["SURVEY"]]
+    surveys = ["JADES-Deep-GS"] #[config["DEFAULT"]["SURVEY"]]
     aper_diams = [0.32] * u.arcsec
     SED_code_arr = [EAZY()]
     templates_arr = ["fsps_larson"] #["fsps", "fsps_larson", "fsps_jades"]
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     jems_bands = ["F182M", "F210M", "F430M", "F460M", "F480M"]
     ngdeep_excl_bands = ["F435W", "F775W", "F850LP"]
     #jades_3215_excl_bands = ["f162M", "f115W", "f150W", "f200W", "f410M", "f182M", "f210M", "f250M", "f300M", "f335M", "f277W", "f356W", "f444W"] 
-    excl_bands = []
+    excl_bands = ['F162M', 'F182M', 'F210M', 'F430M', 'F460M', 'F480M']
 
     SED_fit_params_arr = make_EAZY_SED_fit_params_arr(SED_code_arr, templates_arr, lowz_zmax_arr)
 

--- a/galfind/Instrument.py
+++ b/galfind/Instrument.py
@@ -126,20 +126,13 @@ class Instrument:
                 raise(Exception("Cannot add multiple of the same band together in 'Instrument.__add__()'!"))
         
         # add and sort bands from blue -> red
-        all_bands = json.loads(config.get("Other", "ALL_BANDS"))
-        # print("all bands = ", all_bands, type(all_bands), type(all_bands[0]))
-        bands = [band for band in all_bands if band.__class__.__name__ in np.concatenate([self.bands, instrument.bands])]
-        #self.band_wavelengths.update(instrument.band_wavelengths)
-        #band_wavelengths = self.band_wavelengths
-        #self.band_FWHMs.update(instrument.band_FWHMs)
-        #band_FWHMs = self.band_FWHMs
-        
+        bands = [band for band in sorted(np.concatenate([self.bands, instrument.bands]), \
+            key = lambda band: band.WavelengthCen.to(u.AA).value)]
+
         # always name instruments from blue -> red
        
         if self.name == instrument.name:
             self.bands = bands
-            #self.band_wavelengths = band_wavelengths
-            #self.band_FWHMs = band_FWHMs
             out_instrument = self
         else:
             all_instruments = json.loads(config.get("Other", "INSTRUMENT_NAMES"))
@@ -203,15 +196,17 @@ class Instrument:
     def remove_band(self, band_name) -> NoReturn:
         assert type(band_name) in [str, np.str_], galfind_logger.critical(f"{band_name=} with {type(band_name)=} not in ['str', 'np.str_']")
         assert band_name in self.band_names, galfind_logger.critical(f"{band_name=} not in {self.band_names=}")
-        remove_index = self.index_from_band_name(band_name)
-        self.bands = np.delete(self.bands, remove_index)
+        self.remove_index(self.index_from_band_name(band_name))
         
     def remove_index(self, remove_index: int) -> NoReturn:
-        remove_band = self.band_name_from_index(remove_index)
-        self.remove_band(remove_band)
+        if not remove_index == None:
+            self.bands = np.delete(self.bands, remove_index)
         
     def index_from_band_name(self, band_name) -> int:
-        return np.where(self.band_names == band_name)[0][0]
+        if band_name in self.band_names:
+            return np.where(self.band_names == band_name)[0][0]
+        else:
+            return None
     
     def band_name_from_index(self, index) -> str:
         return self.band_names[index]
@@ -275,7 +270,7 @@ class Instrument:
 class NIRCam(Instrument):
     
     def __init__(self, excl_bands = []):
-        instr = Instrument.from_SVO("JWST", self.__class__.__name__, excl_bands = excl_bands)
+        instr = Instrument.from_SVO("JWST", self.__class__.__name__, excl_bands = [])
         super().__init__(instr.name, instr.bands, excl_bands, instr.facility)
         # bands = ["f070W", "f090W", "f115W", "f140M", "f150W", "f162M", "f182M", "f200W", "f210M", "f250M", "f277W", "f300M", "f335M", "f356W", "f360M", "f410M", "f430M", "f444W", "f460M", "f480M"]
         # band_wavelengths = {"f070W": 7_056., "f090W": 9_044., "f115W": 11_571., "f140M": 14_060., "f150W": 15_040., "f162M": 16_281., "f182M": 18_466., "f200W": 19_934., "f210M": 20_964., \
@@ -306,7 +301,7 @@ class NIRCam(Instrument):
 class MIRI(Instrument):
     
     def __init__(self, excl_bands = []):
-        instr = Instrument.from_SVO("JWST", self.__class__.__name__, excl_bands = excl_bands)
+        instr = Instrument.from_SVO("JWST", self.__class__.__name__, excl_bands = [])
         super().__init__(instr.name, instr.bands, excl_bands, instr.facility)
         # bands = ['f560W', 'f770W', 'f1000W', 'f1130W', 'f1280W', 'f1500W', 'f1800W', 'f2100W', 'f2550W']
         # band_wavelengths = {'f560W':55870.25, 'f770W':75224.94, 'f1000W': 98793.45, 'f1130W':112960.71, 'f1280W':127059.68, 'f1500W':149257.07, 'f1800W':178734.17, 'f2100W':205601.06, 'f2550W':251515.99}
@@ -324,7 +319,7 @@ class MIRI(Instrument):
 class ACS_WFC(Instrument):
     
     def __init__(self, excl_bands = []):
-        instr = Instrument.from_SVO("HST", self.__class__.__name__, excl_bands = excl_bands)
+        instr = Instrument.from_SVO("HST", self.__class__.__name__, excl_bands = [])
         super().__init__(instr.name, instr.bands, excl_bands, instr.facility)
         # bands = ["f435W", "fr459M", "f475W", "f550M", "f555W", "f606W", "f625W", "fr647M", "f775W", "f814W", "f850LP", "fr914M"]
         # # Wavelengths corrrespond to lambda effective of the filters from SVO Filter Profile Service
@@ -348,7 +343,7 @@ class ACS_WFC(Instrument):
 class WFC3_IR(Instrument):
 
     def __init__(self, excl_bands = []):
-        instr = Instrument.from_SVO("HST", self.__class__.__name__, excl_bands = excl_bands)
+        instr = Instrument.from_SVO("HST", self.__class__.__name__, excl_bands = [])
         super().__init__(instr.name, instr.bands, excl_bands, instr.facility)
         # bands = ["f098M", "f105W",  "f110W", "f125W", "f127M", "f139M", "f140W", "f153M", "f160W"]
         # # Wavelengths corrrespond to lambda effective of the filters from SVO Filter Profile Service

--- a/galfind/__init__.py
+++ b/galfind/__init__.py
@@ -97,8 +97,18 @@ from . import NIRCam_aperture_corrections as NIRCam_aper_corr
 from . import Depths
 from .PDF import PDF, Redshift_PDF, PDF_nD
 from .Filter import Filter
-from .Data import Data
 from .Instrument import Instrument, ACS_WFC, WFC3_IR, NIRCam, MIRI, Combined_Instrument
+
+# ordered band names from blue -> red
+#config.set("Other", "ALL_BANDS", json.dumps(["F435W","FR459M","F475W","F550M","F555W","F606W","F625W","FR647M","F070W","F775W","F814W","F850LP",
+#             "F090W","FR914M","F098M","F105W","F110W","F115W","F125W","F127M","F139M","F140W","F140M","F150W","F153M","F160W","F162M","F182M",
+#             "F200W","F210M","F250M","F277W","F300M","F335M","F356W","F360M","F410M","F430M","F444W","F460M","F480M","F560W","F770W","F1000W","F1130W","F1280W","F1500W","F1800W","F2100W","F2550W"]))
+all_bands = np.hstack([subcls().bands for subcls in Instrument.__subclasses__() if subcls.__name__ != "Combined_Instrument"])
+# sort bands blue -> red based on central wavelength
+all_band_names = [band.band_name for band in sorted(all_bands, key = lambda band: band.WavelengthCen.to(u.AA).value)]
+config.set("Other", "ALL_BANDS", json.dumps(all_band_names))
+
+from .Data import Data
 from .Photometry import Photometry, Multiple_Photometry, Mock_Photometry
 from .Photometry_obs import Photometry_obs, Multiple_Photometry_obs
 from .Photometry_rest import Photometry_rest
@@ -124,13 +134,6 @@ from . import lyman_alpha_damping_wing
 from .DLA import DLA
 from .Dust_Attenuation import Dust_Attenuation, Calzetti00
 from .Spectrum import Spectral_Catalogue, Spectrum, NIRSpec, Spectral_Instrument, Spectral_Filter, Spectral_Grating
-
-# ordered band names from blue -> red
-config.set("Other", "ALL_BANDS", json.dumps(["F435W","FR459M","F475W","F550M","F555W","F606W","F625W","FR647M","F070W","F775W","F814W","F850LP",
-             "F090W","FR914M","F098M","F105W","F110W","F115W","F125W","F127M","F139M","F140W","F140M","F150W","F153M","F160W","F162M","F182M",
-             "F200W","F210M","F250M","F277W","F300M","F335M","F356W","F360M","F410M","F430M","F444W","F460M","F480M","F560W","F770W","F1000W","F1130W","F1280W","F1500W","F1800W","F2100W","F2550W"]))
-# print(np.array([getattr(globals()[subcls.__class__.__name__], subcls.__class__.__name__)() for subcls in Instrument.__subclasses__()]).flatten())
-# config.set("Other", "ALL_BANDS", json.dumps(np.array([subcls().band_names for subcls in Instrument.__subclasses__]).flatten()))
 
 # dynamically add Galaxy selection methods to Catalogue class?
 


### PR DESCRIPTION
Now dynamically adds all the band names in __init__ rather than requiring them to be typed. excl_bands now not being removed twice in Instrument.__subclasses__.__init__(). Instrument.__add__ updated, but should also include functionality to add an array of filter objects as well as an instrument. Data.from_pipeline() requires overhaul to generalize adding more instruments (e.g. so that NIRISS/MIRI don't need to be written here but instead use "for instr in instruments" rather than if/else). 