### PR TITLE
Dependency fix for BDFit and Bagpipes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ dependencies = [
   "ipykernel",
   "emcee",
   "lmfit",
+  "spectres",
   "BDFit @ git+https://github.com/tHarvey303/BD-Finder/",
   "corner",
 ]


### PR DESCRIPTION
Update BDFit and bagpipes dependencies to link to correct GitHub repositories

bagpipes is optional and can be installed with

`pip install . [bagpipes]`